### PR TITLE
Update enqueue/dsn to latest stable version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,8 +20,8 @@
   "require": {
     "php": "^7.1.3",
     "queue-interop/queue-interop": "^0.7|^0.8",
-    "enqueue/dsn": "^0.9",
-    "aws/aws-sdk-php": "~3.26"
+    "enqueue/dsn": "^0.10",
+    "aws/aws-sdk-php": "^3.171"
   },
   "require-dev": {
     "phpunit/phpunit": "~5.4.0",
@@ -38,5 +38,5 @@
       "Brighte\\Sns\\Tests\\": "tests/"
     }
   },
-  "minimum-stability": "dev"
+  "minimum-stability": "stable"
 }


### PR DESCRIPTION
brightecapital/brighte-sdk 
 -> uses this packages 

The goal is to update the portal AWS-SDK and brighter queue client package.

